### PR TITLE
Differentiates the type of error that led to python crashing

### DIFF
--- a/BASEplate.js
+++ b/BASEplate.js
@@ -13,7 +13,7 @@ child.on('error', (err) => {
 
 child.on('exit', (code, signal) => {
     console.log(`code: ${code} signal: ${signal}`);
-    child_status = 1;
+    child_status = code;
 });
 
 child.stderr.on('data', (data) => {
@@ -43,12 +43,24 @@ class BASEplate {
         this.addr = addr;
         this.plate_type = plate_type;
         this.queue = queue;
-        this.plate_status = 3; //0 = no error, 1 = not found, 2 = python error, 3 = unknown
+
+        /* plate_status stores information about whether or not this plate can currently
+         * be used, or if there is an issue:
+         * 0 = no error
+         * 1 = plate not found
+         * 2 = missing python dependencies
+         * 3 = unknown python error
+         * 4 = unknown state
+         */
+        this.plate_status = 4;
+
         this.update_status();
     }
+
+    // Updates this.plate_status.
     update_status () {
         if (child_status) {
-            this.plate_status = 2;
+            this.plate_status = child_status;
         }else {
             const verifier = {cmd: "VERIFY", args: {}};
 

--- a/plate_io.py
+++ b/plate_io.py
@@ -9,7 +9,7 @@ try:
     import piplates.THERMOplate as TP
     import piplates.TINKERplate as TINK
 except:
-    sys.exit(1)
+    sys.exit(2)
 
 # All Pi Plate communication must go through this one process to ensure
 # SPI communications don't overlap / interfere and corrupt the device state(s)
@@ -20,9 +20,6 @@ except:
 #   plate_type: <RELAY|DAQC>,
 #   cmd: <command string>, args: {<command-specific args>}
 # }
-
-#TODO: scan for plates at startup so we can handle wrong-address
-#      or plate_type mismatch exceptions
 
 while True:
     try:
@@ -289,5 +286,5 @@ while True:
         else:
             sys.stderr.write("unknown plate_type: " + plate_type)
     except (EOFError, SystemExit, AssertionError):
-        sys.exit(0)
+        sys.exit(3)
 

--- a/plate_io.py
+++ b/plate_io.py
@@ -34,13 +34,13 @@ while True:
         if (plate_type == "RELAY"):
             if (cmd == "setLED"):
                 RP.setLED(addr)
-                resp['LED'] = 1
+                resp['state'] = 1
             elif (cmd == "clrLED"):
                 RP.clrLED(addr)
-                resp['LED'] = 0
+                resp['state'] = 0
             elif (cmd == "toggleLED"):
                 RP.toggleLED(addr)
-                resp['LED'] = "UNKNOWN"
+                resp['state'] = "UNKNOWN"
             elif (cmd == "getID"):
                 resp['ID'] = RP.getID(addr)
             elif (cmd == "getHWrev"):
@@ -160,7 +160,7 @@ while True:
                 else:
                     sys.stderr.write("unsupported LED color: " + color)
 
-                resp['color'] = color
+                resp['state'] = color
             elif (cmd == "setLED" and plate_type == "DAQC2"):
                 color = args['color']
 
@@ -169,7 +169,7 @@ while True:
                 else:
                     sys.stderr.write("unsupported LED color: " + color)
 
-                resp['color'] = color
+                resp['state'] = color
             elif (cmd == "VERIFY" and plate_type == "DAQC"):
                 #For some reason the DAQC plate's getADDR method adds 8 to the address.
                 if(DP.getADDR(addr) - 8 == addr):
@@ -205,13 +205,13 @@ while True:
                 resp['value'] = value
             elif (cmd == "setLED"):
                 TP.setLED(addr)
-                resp['LED'] = 1
+                resp['state'] = 1
             elif (cmd == "clrLED"):
                 TP.clrLED(addr)
-                resp['LED'] = 0
+                resp['state'] = 0
             elif (cmd == "toggleLED"):
                 TP.toggleLED(addr)
-                resp['LED'] = TP.getLED(addr)
+                resp['state'] = TP.getLED(addr)
             elif (cmd == "VERIFY"):
                 if(TP.getADDR(addr) == addr):
                     resp['state'] = 0


### PR DESCRIPTION
If python crashes because of missing dependencies, the plate_status is set to 2. If it fails for any other reason, it's set to 3. This allows the plate to differentiate between errors.